### PR TITLE
fix: esix template-variables must not contain hyphens

### DIFF
--- a/src/template/esix/StringCompiler.js
+++ b/src/template/esix/StringCompiler.js
@@ -47,6 +47,15 @@ export default class extends Compiler {
      * @inheritdoc
      */
     compile (txt, keys) {
+
+        keys.some(key => {
+            if (key.indexOf("-") !== -1) {
+                throw new Error(
+                    `Cannot compile template: Contains invalid key-name: ${key}`
+                );
+            }
+        });
+
         const
             me = this,
             tplKeys = me.getKeys(txt),
@@ -109,11 +118,11 @@ export default class extends Compiler {
             // The result can be accessed through the `m`-variable.
             m.forEach((match, groupIndex) => {
                 if (groupIndex === 1) {
-                    keys.push(match);   
+                    keys.push(match);
                 }
             });
         }
-        
+
         return keys;
     }
 
@@ -168,5 +177,5 @@ export default class extends Compiler {
     getNativeFunction (args, body) {
         return new Function(args, body);
     }
-    
+
 }

--- a/tests/template/esix/StringTemplate.test.js
+++ b/tests/template/esix/StringTemplate.test.js
@@ -124,3 +124,8 @@ test("render() - exception", () => {
     expect(() => {inst.render({a : 1, b : 2});}).toThrow(/compiled tpl render/);
 });
 
+
+test("hyphen in template", () => {
+    expect(() => make("This is a ${templated-hyphened}")
+        .render({"templated-hyphened": "ignored"})).toThrow(/invalid key-name/);
+});


### PR DESCRIPTION
refs @l8js/l8#26